### PR TITLE
test: add 3 playwright end-to-end behavior tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,24 @@ playwright install chromium
 shiny run --reload src/app.py
 ```
 
+7. Run the test suite:
+
+To install playwright:
+```bash
+playwright install
+```
+
+```bash
+# Unit tests only (fast)
+pytest -v --ignore=tests/test_app_playwright.py
+
+# Playwright end-to-end tests (requires playwright installed)
+pytest tests/test_app_playwright.py -v
+
+# All tests
+pytest -v
+```
+
 ## Contributors
 
 - Seungmyun Park

--- a/src/pages/company.py
+++ b/src/pages/company.py
@@ -1,6 +1,6 @@
 """Page 2: Company Financial Health — UI layout and server logic."""
 
-from shiny import reactive, render, ui
+from shiny import reactive, render, ui, req
 from shinywidgets import output_widget, render_altair
 
 from charts.altair_charts import (
@@ -151,7 +151,7 @@ def company_server(input, output, session):
     @render.ui
     def p2_year_slider():
         company = input.company()
-        company_expr = tbl.filter[tbl["Company"] == company]
+        company_expr = tbl.filter(tbl["Company"] == company)
         company_data = company_expr.to_pandas()
         if company_data.empty:
             year_min = YEAR_MIN
@@ -190,6 +190,7 @@ def company_server(input, output, session):
         category = input.category()
         company = input.company()
         year = input.year()
+        req(category, company, year)  # Ensure all inputs are available before filtering
         expr = tbl.filter(
             tbl["Category"] == category, tbl["Company"] == company, tbl["Year"] == year
         )
@@ -275,7 +276,7 @@ def company_server(input, output, session):
     @render_altair
     def p2_revenue_chart():
         company_data = p2_company_data()
-        company = input.company
+        company = input.company()
         if company_data.empty:
             return empty_chart()
         return build_revenue_over_time(company_data, company)

--- a/tests/test_app_playwright.py
+++ b/tests/test_app_playwright.py
@@ -1,0 +1,82 @@
+# tests/test_app_playwright.py
+"""Playwright end-to-end behavior tests for the fin-health dashboard."""
+
+import re
+
+from playwright.sync_api import Page, expect
+from shiny.playwright import controller
+from shiny.pytest import create_app_fixture
+from shiny.run import ShinyAppProc
+
+app = create_app_fixture("../src/app.py")
+
+
+def test_initial_page_loads(page: Page, app: ShinyAppProc):
+    """Dashboard loads and Page 1 KPI value boxes display non-empty initial values."""
+    page.goto(app.url)
+
+    # Wait for the page title to confirm app loaded
+    expect(page.locator("text=US Corporate Profitability Analytics")).to_be_visible(
+        timeout=30_000
+    )
+
+    # Verify KPI cards render with actual values (not empty or "Data Unavailable")
+    avg_margin = controller.OutputText(page, "p1_avg_margin")
+    avg_margin.expect_value(re.compile(r"-?\d+\.\d+%"), timeout=15_000)
+
+    top_sector = controller.OutputText(page, "p1_top_sector")
+    top_sector.expect_value(re.compile(r"[A-Z]+"), timeout=15_000)
+
+    revenue_growth = controller.OutputText(page, "p1_revenue_growth_value")
+    revenue_growth.expect_value(re.compile(r"[+-]?\d+\.\d+%"), timeout=15_000)
+
+
+def test_sector_filter_updates_kpis(page: Page, app: ShinyAppProc):
+    """Selecting a specific sector in the dropdown updates KPI values and chart outputs."""
+    page.goto(app.url)
+
+    # Wait for initial load
+    avg_margin = controller.OutputText(page, "p1_avg_margin")
+    avg_margin.expect_value(re.compile(r"-?\d+\.\d+%"), timeout=15_000)
+
+    # Select a specific sector (IT) to filter
+    sector_select = controller.InputSelectize(page, "p1_sector")
+    sector_select.set("IT")
+
+    # After filtering to IT only, the top sector should be IT
+    top_sector = controller.OutputText(page, "p1_top_sector")
+    top_sector.expect_value("IT", timeout=15_000)
+
+    # Verify the avg margin updated (should still show a valid percentage)
+    avg_margin.expect_value(re.compile(r"-?\d+\.\d+%"), timeout=15_000)
+
+
+def test_company_page_navigation_and_selection(page: Page, app: ShinyAppProc):
+    """Navigating to Page 2 and selecting a company renders correct KPI values."""
+    page.goto(app.url)
+
+    # Wait for initial page load
+    expect(page.locator("text=US Corporate Profitability Analytics")).to_be_visible(
+        timeout=30_000
+    )
+
+    # Navigate to Page 2 (Company Health)
+    page.locator("a.nav-link", has_text="Company Health").click()
+
+    # Wait for Page 2 content
+    expect(
+        page.get_by_role("heading", name="Financial Health Dashboard")
+    ).to_be_visible(timeout=15_000)
+
+    # Verify KPI values are rendered (not "N/A")
+    npm = controller.OutputText(page, "p2_npm")
+    npm.expect_value(re.compile(r"-?\d+\.\d+%"), timeout=30_000)
+
+    roe = controller.OutputText(page, "p2_roe")
+    roe.expect_value(re.compile(r"-?\d+\.\d+%"), timeout=15_000)
+
+    current_ratio = controller.OutputText(page, "p2_current_ratio")
+    current_ratio.expect_value(re.compile(r"\d+\.\d+"), timeout=15_000)
+
+    debt_equity = controller.OutputText(page, "p2_debt_equity")
+    debt_equity.expect_value(re.compile(r"-?\d+\.\d+"), timeout=15_000)


### PR DESCRIPTION
## Summary
- Created `tests/test_app_playwright.py` with 3 end-to-end behavior tests:
  - `test_initial_page_loads` — verifies dashboard loads and Page 1 KPIs display values
  - `test_sector_filter_updates_kpis` — verifies sector dropdown selection updates KPIs
  - `test_company_page_navigation_and_selection` — verifies Page 2 navigation and company KPIs
- Updated `README.md` with test running instructions
- Changes to src/pages/company.py are to resolve the below error
<img width="1608" height="1003" alt="image" src="https://github.com/user-attachments/assets/0e728e8f-a6af-4f6b-ac3d-39cd30cd815b" />


## Test plan
- [x] Run `pytest tests/test_app_playwright.py -v` — all 3 tests pass
- [x] Run `pytest tests/ -v --ignore=tests/test_querychat_behavior.py` — all tests pass
- [x] Verify README test instructions are accurate