### PR TITLE
chore: add scikit-learn to runtime dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,5 @@ vegafusion==2.0.3
 # AI & Utilities
 chatlas==0.15.2
 querychat==0.5.1
+scikit-learn==1.8.0
 python-dotenv==1.2.2


### PR DESCRIPTION
Fixes #71

### Proposed Changes
  - Add `scikit-learn` in runtime dependecies for RAG