### PR TITLE
feat: add status icon and metric definition tooltips to Company Health page

### DIFF
--- a/src/pages/company.py
+++ b/src/pages/company.py
@@ -12,6 +12,32 @@ from components.empty_chart import empty_chart
 from components.health_status import classify_health, format_currency
 from data import ALL_SECTORS, CATEGORY_COMPANIES, YEAR_MIN, YEAR_MAX, tbl
 
+_METRIC_DEFINITIONS = {
+    "Net Profit Margin": "Percentage of revenue remaining after all expenses. Higher is better.",
+    "Return on Equity (ROE)": "How effectively a company uses shareholders' equity to generate profit.",
+    "Revenue & Net Income": "Revenue is total sales; Net Income is profit after all expenses.",
+    "Current Ratio": "Ability to pay short-term debts. Above 1.0 means more assets than liabilities.",
+    "Debt / Equity Ratio": "Total debt relative to shareholders' equity. Lower generally means less risk.",
+    "Cash Flows": "Money moving in and out: operating (core business), investing (assets), and financing (debt/equity).",
+}
+
+
+def _card_header_with_tooltip(header: str):
+    """Card header with an info icon that shows a metric definition on hover."""
+    definition = _METRIC_DEFINITIONS.get(header, "")
+    if not definition:
+        return ui.card_header(header)
+    return ui.card_header(
+        ui.tags.span(
+            header,
+            ui.tags.span(
+                " \u24d8",
+                title=definition,
+                style="cursor: help; opacity: 0.5; font-size: 0.85em;",
+            ),
+        )
+    )
+
 
 def company_ui():
     """Return the full Page 2 layout."""
@@ -38,7 +64,7 @@ def company_ui():
 
     # Profitability cards — mirror Financial Health layout (KPI + status + chart)
     card_npm = ui.card(
-        ui.card_header("Net Profit Margin"),
+        _card_header_with_tooltip("Net Profit Margin"),
         ui.div(
             ui.tags.h3(
                 ui.output_text("p2_npm", inline=True),
@@ -52,7 +78,7 @@ def company_ui():
         full_screen=True,
     )
     card_roe = ui.card(
-        ui.card_header("Return on Equity (ROE)"),
+        _card_header_with_tooltip("Return on Equity (ROE)"),
         ui.div(
             ui.tags.h3(
                 ui.output_text("p2_roe", inline=True),
@@ -66,7 +92,7 @@ def company_ui():
         full_screen=True,
     )
     card_rev_income = ui.card(
-        ui.card_header("Revenue & Net Income"),
+        _card_header_with_tooltip("Revenue & Net Income"),
         ui.output_ui("p2_rev_income_summary"),
         output_widget("p2_revenue_chart"),
         full_screen=True,
@@ -84,7 +110,7 @@ def company_ui():
 
     # Financial Health cards (reactive outputs)
     card_current_ratio = ui.card(
-        ui.card_header("Current Ratio"),
+        _card_header_with_tooltip("Current Ratio"),
         ui.div(
             ui.tags.h3(
                 ui.output_text("p2_current_ratio", inline=True),
@@ -98,7 +124,7 @@ def company_ui():
         full_screen=True,
     )
     card_debt_equity = ui.card(
-        ui.card_header("Debt / Equity Ratio"),
+        _card_header_with_tooltip("Debt / Equity Ratio"),
         ui.div(
             ui.tags.h3(
                 ui.output_text("p2_debt_equity", inline=True),
@@ -112,7 +138,7 @@ def company_ui():
         full_screen=True,
     )
     card_cash_flows = ui.card(
-        ui.card_header("Cash Flows"),
+        _card_header_with_tooltip("Cash Flows"),
         ui.output_ui("p2_cash_flows"),
         output_widget("p2_cash_flow_chart"),
         full_screen=True,
@@ -222,10 +248,16 @@ def company_server(input, output, session):
 
     # Status icon mapping for health classification
     _STATUS_ICONS = {"healthy": "\u2713", "warning": "!", "danger": "\u2717"}
+    _STATUS_TOOLTIPS = {
+        "healthy": "Healthy — metric is within a strong range",
+        "warning": "Warning — metric is below the healthy threshold but not critical",
+        "danger": "Danger — metric is in a critical range",
+    }
 
     def _status_badge(status: str):
         icon = _STATUS_ICONS[status]
-        return ui.tags.span(icon, class_=f"kpi-status {status}")
+        tooltip_text = _STATUS_TOOLTIPS[status]
+        return ui.tags.span(icon, class_=f"kpi-status {status}", title=tooltip_text)
 
     @render.ui
     def p2_npm_status():


### PR DESCRIPTION
Fixes #85, Fixes #88, resolves #67

### Proposed Changes
- Added hover tooltips to status badges (green ✓ / yellow ! / red ✗) explaining what each health status means
- Added ⓘ info icon next to all 6 card headers on the Company Health page with plain-language definitions of each financial metric (Net Profit Margin, ROE,  Revenue & Net Income, Current Ratio, Debt/Equity Ratio, Cash Flows)