### PR TITLE
fix: add scatter plot transparency and resolve Revenue-on-both-axes i…

### DIFF
--- a/src/charts/altair_charts.py
+++ b/src/charts/altair_charts.py
@@ -134,22 +134,29 @@ def build_peer_scatter(data: pd.DataFrame, metric: str, unit: str) -> alt.Chart:
     """Scatter plot of Revenue vs selected metric."""
     if data.empty:
         return empty_chart()
+
+    # When metric is Revenue, Y-axis would duplicate X-axis — show Net Income instead
+    y_metric = "Net Income" if metric == "Revenue" else metric
+    y_unit = "USD" if metric == "Revenue" else unit
+
     return (
         alt.Chart(data)
-        .mark_circle(size=60)
+        .mark_circle(size=60, opacity=0.6)
         .encode(
             x=alt.X("Revenue:Q", title="Revenue ($)"),
-            y=alt.Y(f"{metric}:Q", title=f"{metric} {unit}"),
+            y=alt.Y(f"{y_metric}:Q", title=f"{y_metric} {y_unit}"),
             color=alt.Color("Category:N", scale=alt.Scale(range=PALETTE)),
             tooltip=[
                 "Company",
                 "Category",
                 "Year:O",
                 alt.Tooltip("Revenue:Q", format=",.0f"),
-                alt.Tooltip(f"{metric}:Q", format=",.2f"),
+                alt.Tooltip(f"{y_metric}:Q", format=",.2f"),
             ],
         )
-        .properties(title=f"Revenue vs {metric}", width="container", height="container")
+        .properties(
+            title=f"Revenue vs {y_metric}", width="container", height="container"
+        )
     )
 
 

--- a/src/pages/ai_explorer.py
+++ b/src/pages/ai_explorer.py
@@ -38,6 +38,7 @@ GLOSSARY_PATH = (
 
 _orig_update_dashboard_impl = _qc_tools._update_dashboard_impl
 
+
 def _patched_update_dashboard_impl(data_source, update_fn):
     _orig_fn = _orig_update_dashboard_impl(data_source, update_fn)
 
@@ -75,6 +76,7 @@ def _patched_update_dashboard_impl(data_source, update_fn):
         return result
 
     return _wrapper
+
 
 _qc_tools._update_dashboard_impl = _patched_update_dashboard_impl
 
@@ -224,6 +226,7 @@ _kb_chunks: list[str] | None = None
 _kb_vectorizer: TfidfVectorizer | None = None
 _kb_vectors = None
 
+
 def _ensure_kb():
     """Build the TF-IDF knowledge-base index (lazy, once)."""
     global _kb_chunks, _kb_vectorizer, _kb_vectors
@@ -259,7 +262,11 @@ def _ensure_kb():
     _kb_vectorizer = TfidfVectorizer()
     _kb_vectors = _kb_vectorizer.fit_transform(_kb_chunks)
 
-_RAG_MAX_CHARS = 2500 # ~625 tokens (per query) — leaves room for system prompt + chat history
+
+_RAG_MAX_CHARS = (
+    2500  # ~625 tokens (per query) — leaves room for system prompt + chat history
+)
+
 
 def _retrieve(query: str, top_k: int = 3) -> list[str]:
     """Return relevant glossary chunks within a character budget."""
@@ -287,6 +294,7 @@ def _retrieve(query: str, top_k: int = 3) -> list[str]:
         else:
             break
     return selected
+
 
 class _RAGChat(Chat):
     """Chat subclass that injects per-query RAG context.
@@ -327,6 +335,7 @@ class _RAGChat(Chat):
             else:
                 raise
 
+
 @cache
 def _get_qc():
     """Lazily create the QueryChat instance (deferred until first use)."""
@@ -341,6 +350,7 @@ def _get_qc():
         greeting=GREETING,
         client=client,
     )
+
 
 def _has_token():
     """Check whether GITHUB_TOKEN is available."""


### PR DESCRIPTION
Fixes #69, Fixes #85, Fixes #88

### Proposed Changes
- Added `opacity=0.6` to `mark_circle()` in `build_peer_scatter` so overlapping
  data points are visually distinguishable (flagged by 3 reviewers)
- When the selected metric is `Revenue`, the Y-axis now falls back to `Net Income`
  instead of duplicating Revenue on both axes


Get review, then merge.
